### PR TITLE
Avoid duplicate declaration by using ensure_packages

### DIFF
--- a/manifests/packages.pp
+++ b/manifests/packages.pp
@@ -13,9 +13,7 @@ class gitlab::packages inherits gitlab {
                     'redis-server',
                     'nginx',
                       ]
-  package { $system_packages:
-    ensure  =>  present,
-  }
+  ensure_packages($system_packages)
 
   ## Git v1.7.10
   #=====================================


### PR DESCRIPTION
Changed the installation of $system_packages to use ensure_packages to avoid any duplicate declaration in common packages.

Let me know if you would like some in-line comments or anything.

```
ensure_packages
Takes a list of packages and only installs them if they don't already exist.
```
