### PR TITLE
Add 'git_ssh_port' parameter to make the SSH port configurable.

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,6 +233,7 @@ All of the parameters that can be set
     git_home                 # Default /home/git
     git_email                # The email address gitlab will send email from 
     git_comment              # Arbitrary unix identifier, Default 'gitlab'
+    git_ssh_port             # SSH port, Default '22'
     gitlab_sources           # git URL with gitlab source
     gitlabshell_sources      # git URL with gitlabshell source
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -8,6 +8,7 @@ class gitlab (
     $git_home               = $gitlab::params::git_home,
     $git_email              = $gitlab::params::git_email,
     $git_comment            = $gitlab::params::git_comment,
+    $git_ssh_port           = $gitlab::params::git_ssh_port,
     $gitlab_sources         = $gitlab::params::gitlab_sources,
     $gitlabshell_sources    = $gitlab::params::gitlabshell_sources,
     

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -8,6 +8,7 @@ class gitlab::params {
   $git_home               = '/home/git'
   $git_email              = 'git@someserver.net'
   $git_comment            = 'GitLab'
+  $git_ssh_port           = '22'
   $gitlab_sources         = 'git://github.com/gitlabhq/gitlabhq.git'
   $gitlabshell_sources    = 'git://github.com/gitlabhq/gitlab-shell.git' 
   

--- a/templates/gitlab.yml.6-0-stable.erb
+++ b/templates/gitlab.yml.6-0-stable.erb
@@ -58,7 +58,7 @@ production: &base
       wall: <%= @project_wall %>  #default false
       snippets: <%= @project_snippets %> #default false
       #public: false #New to 6.1
-    
+
 
   ## External issues trackers
   issues_tracker:
@@ -81,7 +81,7 @@ production: &base
     #   ##  :project_id        - GitLab project identifier
     #   ##  :issues_tracker_id - Project Name or Id in external issue tracker
     #   new_issue_url: "http://redmine.sample/projects/:issues_tracker_id/issues/new"
-    # 
+    #
     # jira:
     #   project_url: "http://jira.sample/issues/?jql=project=:issues_tracker_id"
     #   issues_url: "http://jira.sample/browse/:id"
@@ -100,7 +100,7 @@ production: &base
   ## LDAP settings
   ldap:
     enabled: <%= @ldap_enabled %>
-    host:  '<%= @ldap_host %>' 
+    host:  '<%= @ldap_host %>'
     base:  '<%= @ldap_base %>'
     port:  <%= @ldap_port %>
     uid:   '<%= @ldap_uid %>'        #example 'sAMAccountName'
@@ -164,7 +164,7 @@ production: &base
     receive_pack: true
 
     # If you use non-standard ssh port you need to specify it
-    # ssh_port: 22
+    ssh_port: <%= @git_ssh_port %>
 
   ## Git settings
   # CAUTION!

--- a/templates/gitlab.yml.6-1-stable.erb
+++ b/templates/gitlab.yml.6-1-stable.erb
@@ -58,7 +58,7 @@ production: &base
       wall: <%= @project_wall %>  #default false
       snippets: <%= @project_snippets %> #default false
       public: <%= @project_public_default %> #default false #New to 6.1
-    
+
 
   ## External issues trackers
   issues_tracker:
@@ -81,7 +81,7 @@ production: &base
     #   ##  :project_id        - GitLab project identifier
     #   ##  :issues_tracker_id - Project Name or Id in external issue tracker
     #   new_issue_url: "http://redmine.sample/projects/:issues_tracker_id/issues/new"
-    # 
+    #
     # jira:
     #   project_url: "http://jira.sample/issues/?jql=project=:issues_tracker_id"
     #   issues_url: "http://jira.sample/browse/:id"
@@ -100,7 +100,7 @@ production: &base
   ## LDAP settings
   ldap:
     enabled: <%= @ldap_enabled %>
-    host:  '<%= @ldap_host %>' 
+    host:  '<%= @ldap_host %>'
     base:  '<%= @ldap_base %>'
     port:  <%= @ldap_port %>
     uid:   '<%= @ldap_uid %>'        #example 'sAMAccountName'
@@ -164,7 +164,7 @@ production: &base
     receive_pack: true
 
     # If you use non-standard ssh port you need to specify it
-    # ssh_port: 22
+    ssh_port: <%= @git_ssh_port %>
 
   ## Git settings
   # CAUTION!

--- a/templates/gitlab.yml.6-2-stable.erb
+++ b/templates/gitlab.yml.6-2-stable.erb
@@ -55,7 +55,7 @@ production: &base
 
 
     ## Users management
-    # default: false - Account passwords are not sent via the email if signup is enabled. 
+    # default: false - Account passwords are not sent via the email if signup is enabled.
     # signup_enabled: true
 
     ## Automatic issue closing
@@ -97,7 +97,7 @@ production: &base
     #   ##  :project_id        - GitLab project identifier
     #   ##  :issues_tracker_id - Project Name or Id in external issue tracker
     #   new_issue_url: "http://redmine.sample/projects/:issues_tracker_id/issues/new"
-    # 
+    #
     # jira:
     #   title: "Atlassian Jira"
     #   project_url: "http://jira.sample/issues/?jql=project=:issues_tracker_id"
@@ -117,7 +117,7 @@ production: &base
   ## LDAP settings
   ldap:
     enabled: <%= @ldap_enabled %>
-    host:  '<%= @ldap_host %>' 
+    host:  '<%= @ldap_host %>'
     base:  '<%= @ldap_base %>'
     port:  <%= @ldap_port %>
     uid:   '<%= @ldap_uid %>'        #example 'sAMAccountName'
@@ -180,7 +180,7 @@ production: &base
     receive_pack: true
 
     # If you use non-standard ssh port you need to specify it
-    # ssh_port: 22
+    ssh_port: <%= @git_ssh_port %>
 
   ## Git settings
   # CAUTION!

--- a/templates/gitlab.yml.6-3-stable.erb
+++ b/templates/gitlab.yml.6-3-stable.erb
@@ -55,7 +55,7 @@ production: &base
 
 
     ## Users management
-    # default: false - Account passwords are not sent via the email if signup is enabled. 
+    # default: false - Account passwords are not sent via the email if signup is enabled.
     # signup_enabled: false
 
     ## Automatic issue closing
@@ -97,7 +97,7 @@ production: &base
     #   ##  :project_id        - GitLab project identifier
     #   ##  :issues_tracker_id - Project Name or Id in external issue tracker
     #   new_issue_url: "http://redmine.sample/projects/:issues_tracker_id/issues/new"
-    # 
+    #
     # jira:
     #   title: "Atlassian Jira"
     #   project_url: "http://jira.sample/issues/?jql=project=:issues_tracker_id"
@@ -117,7 +117,7 @@ production: &base
   ## LDAP settings
   ldap:
     enabled: <%= @ldap_enabled %>
-    host:  '<%= @ldap_host %>' 
+    host:  '<%= @ldap_host %>'
     base:  '<%= @ldap_base %>'
     port:  <%= @ldap_port %>
     uid:   '<%= @ldap_uid %>'        #example 'sAMAccountName'
@@ -181,7 +181,7 @@ production: &base
     receive_pack: true
 
     # If you use non-standard ssh port you need to specify it
-    # ssh_port: 22
+    ssh_port: <%= @git_ssh_port %>
 
   ## Git settings
   # CAUTION!

--- a/templates/gitlab.yml.6-4-stable.erb
+++ b/templates/gitlab.yml.6-4-stable.erb
@@ -23,7 +23,7 @@ production: &base
     https: <%= @gitlab_ssl %>
 
     # Uncomment and customize the last line to run in a non-root path
-    # WARNING: We recommend creating a FQDN to host GitLab in a root path instead of this. 
+    # WARNING: We recommend creating a FQDN to host GitLab in a root path instead of this.
     # Note that four settings need to be changed for this to work.
     # 1) In your application.rb file: config.relative_url_root = "/gitlab"
     # 2) In your gitlab.yml file: relative_url_root: /gitlab
@@ -57,7 +57,7 @@ production: &base
 
 
     ## Users management
-    # default: false - Account passwords are not sent via the email if signup is enabled. 
+    # default: false - Account passwords are not sent via the email if signup is enabled.
     # signup_enabled: false
 
     # Restrict setting visibility levels for non-admin users.
@@ -101,7 +101,7 @@ production: &base
     #   ##  :project_id        - GitLab project identifier
     #   ##  :issues_tracker_id - Project Name or Id in external issue tracker
     #   new_issue_url: "http://redmine.sample/projects/:issues_tracker_id/issues/new"
-    # 
+    #
     # jira:
     #   title: "Atlassian Jira"
     #   project_url: "http://jira.sample/issues/?jql=project=:issues_tracker_id"
@@ -123,7 +123,7 @@ production: &base
   #   bundle exec rake gitlab:ldap:check[100] RAILS_ENV=production
   ldap:
     enabled: <%= @ldap_enabled %>
-    host:  '<%= @ldap_host %>' 
+    host:  '<%= @ldap_host %>'
     base:  '<%= @ldap_base %>'
     port:  <%= @ldap_port %>
     uid:   '<%= @ldap_uid %>'        #example 'sAMAccountName'
@@ -188,7 +188,7 @@ production: &base
     receive_pack: true
 
     # If you use non-standard ssh port you need to specify it
-    # ssh_port: 22
+    ssh_port: <%= @git_ssh_port %>
 
   ## Git settings
   # CAUTION!

--- a/templates/gitlab.yml.6-5-stable.erb
+++ b/templates/gitlab.yml.6-5-stable.erb
@@ -20,7 +20,7 @@ production: &base
     https: <%= @gitlab_ssl %>
 
     # Uncomment and customize the last line to run in a non-root path
-    # WARNING: We recommend creating a FQDN to host GitLab in a root path instead of this. 
+    # WARNING: We recommend creating a FQDN to host GitLab in a root path instead of this.
     # Note that four settings need to be changed for this to work.
     # 1) In your application.rb file: config.relative_url_root = "/gitlab"
     # 2) In your gitlab.yml file: relative_url_root: /gitlab
@@ -54,7 +54,7 @@ production: &base
 
 
     ## Users management
-    # default: false - Account passwords are not sent via the email if signup is enabled. 
+    # default: false - Account passwords are not sent via the email if signup is enabled.
     # signup_enabled: true
 
     # Restrict setting visibility levels for non-admin users.
@@ -98,7 +98,7 @@ production: &base
     #   ##  :project_id        - GitLab project identifier
     #   ##  :issues_tracker_id - Project Name or Id in external issue tracker
     #   new_issue_url: "http://redmine.sample/projects/:issues_tracker_id/issues/new"
-    # 
+    #
     # jira:
     #   title: "Atlassian Jira"
     #   project_url: "http://jira.sample/issues/?jql=project=:issues_tracker_id"
@@ -120,7 +120,7 @@ production: &base
   #   bundle exec rake gitlab:ldap:check RAILS_ENV=production
   ldap:
     enabled: <%= @ldap_enabled %>
-    host:  '<%= @ldap_host %>' 
+    host:  '<%= @ldap_host %>'
     base:  '<%= @ldap_base %>'
     port:  <%= @ldap_port %>
     uid:   '<%= @ldap_uid %>'        #example 'sAMAccountName'
@@ -195,7 +195,7 @@ production: &base
     receive_pack: true
 
     # If you use non-standard ssh port you need to specify it
-    # ssh_port: 22
+    ssh_port: <%= @git_ssh_port %>
 
   ## Git settings
   # CAUTION!


### PR DESCRIPTION
This PR adds support for using a non-standard port for SSH though a new `git_ssh_port` parameter, defaulting to the standard port 22.
