### PR TITLE
use ensure_packages to install git-core

### DIFF
--- a/manifests/packages.pp
+++ b/manifests/packages.pp
@@ -10,6 +10,7 @@ class gitlab::packages inherits gitlab {
     
 
   $system_packages = [
+                    'git-core',
                     'libicu-dev',
                     'python2.7',
                     'python-docutils',
@@ -37,13 +38,9 @@ class gitlab::packages inherits gitlab {
       key   =>  'E1DF1F24',
   }
 
-  package { 'git-core':
-    ensure  =>  latest,
-    require =>  [
-        Apt::Ppa['ppa:git-core/ppa'],
-        Apt::Key['ppa:git-core/ppa'],
-                ],
-  }
+  Apt::Ppa['ppa:git-core/ppa'] ->
+    Apt::Key['ppa:git-core/ppa'] ->
+    Package['git-core']
 
 
   ## Ruby


### PR DESCRIPTION
I was running into package conflicts over git-core, which can be remedied by using ensure_packages.  I reduced the git-core package declaration into a set of dependencies, then moved git-core into the $system_packages array.

By applying this patch, it becomes possible to include other puppet modules that specify git-core using ensure_packages.

It's my belief that this patch introduces no net change to the puppet dependency graph compared to the way the git-core package is currently specified in master, but I am not a super puppet hacker and I could be wrong. I am curious to hear any feedback about the patch.
