### PR TITLE
'inherits gitlab' causes namespace traversal problems when component mod...

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -1,5 +1,5 @@
 # init -> packages -> user -> setup -> install -> config -> service
-class gitlab::config inherits gitlab {
+class gitlab::config inherits ::gitlab {
 
   # All file resource declarations should be executed as git:git
   File {

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -73,7 +73,7 @@ class gitlab (
     # Deprecated in 2.0.0
     $project_public_default = ''
 
-  ) inherits gitlab::params {
+  ) inherits ::gitlab::params {
 
 	case $::osfamily {
 	  Debian: {

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -1,5 +1,5 @@
 # init -> packages -> user -> setup -> install -> config -> service
-class gitlab::install inherits gitlab {
+class gitlab::install inherits ::gitlab {
   # Execute all commands as the git user
   Exec {
     user => "${gitlab::git_user}",

--- a/manifests/packages.pp
+++ b/manifests/packages.pp
@@ -4,7 +4,7 @@
 # if set to false, you must manually install all the packages below
 
 # init -> packages -> user -> setup -> install -> config -> service
-class gitlab::packages inherits gitlab {
+class gitlab::packages inherits ::gitlab {
   
   include apt
     

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -1,5 +1,5 @@
 # init -> packages -> user -> setup -> install -> config -> service
-class gitlab::service inherits gitlab {
+class gitlab::service inherits ::gitlab {
 
   # init script
   file { '/etc/init.d/gitlab':

--- a/manifests/setup.pp
+++ b/manifests/setup.pp
@@ -1,5 +1,5 @@
 # init -> packages -> user -> setup -> install -> config -> service  
- class gitlab::setup inherits gitlab {
+ class gitlab::setup inherits ::gitlab {
    
   # Install bundler gem
   package { 'bundler':

--- a/manifests/user.pp
+++ b/manifests/user.pp
@@ -1,5 +1,5 @@
 # init -> packages -> user -> setup -> install -> config -> service
-class gitlab::user inherits gitlab {
+class gitlab::user inherits ::gitlab {
 
 
   # Sets the user to the following useradd --disabled-login --gecos 'Gitlab' git


### PR DESCRIPTION
...ule is wrapped in profile ex: site::profile::gitlab.
