### PR TITLE
Fixed timeout for AWS m1.small

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -11,7 +11,7 @@ class gitlab::install inherits ::gitlab {
     cwd     => "${gitlab::git_home}/gitlab",
     command => "bundle install -j${::processorcount} --deployment --without development test postgres aws",
     unless  => "/usr/bin/test -f ${gitlab::git_home}/.gitlab_setup_done",
-    timeout => 600,
+    timeout => 1800,
     before  => [
            File["${gitlab::git_home}/.gitlab_setup_done"],
            Exec['setup gitlab database'],

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -18,6 +18,7 @@ class gitlab::service inherits ::gitlab {
     user    =>  "${gitlab::git_user}",
     path    =>  '/usr/bin:/usr/sbin:/usr/local/bin:/usr/local/sbin:/sbin:/bin',
     unless  =>  "/usr/bin/test -f ${gitlab::git_home}/.precompile_done",
+    timeout =>  1800,
     before  =>  [
                 File["${gitlab::git_home}/.precompile_done"],
                 Service['gitlab'],


### PR DESCRIPTION
Increased timeout for 'install gitlab' and 'bundle exec rake assets:precompile RAILS_ENV=production' to avoid failing installation caused by slower machines
