### PR TITLE
added support for el6 download url

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -52,7 +52,7 @@ class gitlab::install inherits ::gitlab {
         }
     }
     'RedHat': {
-      $omnibus_release = 'omnibus-1.el6.x86_64.rpm'
+      $omnibus_release = "omnibus-1.el${operatingsystemmajrelease}.x86_64.rpm"
       $url_separator   = '-' #some urls are gitlab-7.0.0 others gitlab_7.0.0
       $package_manager = 'rpm'
 


### PR DESCRIPTION
Hi just a quick fix, I've tested this on centos7 and 6 and it works fine.
