### PR TITLE
Fix downloader

### DIFF
--- a/README.md
+++ b/README.md
@@ -325,7 +325,7 @@ irc     => spuder
 # 
 # [*puppet_manage_packages*]
 #   default => true
-#   Includes packages.pp which installs postfix and openssh
+#   Includes packages.pp which installs curl, postfix and openssh
 #   Gitlab packages will be managed regardless if this parameter is true or false
 #
 # [*external_url*]

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -14,7 +14,7 @@
 # 
 # [*puppet_manage_packages*]
 #   default => true
-#   Includes packages.pp which installs postfix and openssh
+#   Includes packages.pp which installs curl, postfix and openssh
 #   Gitlab packages will be managed regardless if this parameter is true or false
 #
 # [*external_url*]

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -179,17 +179,18 @@ class gitlab::install inherits ::gitlab {
   validate_string($download_location)
   info("omnibus_filename is \'${omnibus_filename}\'")
 
-  package {'wget':
-    ensure  => present,
+  if $::gitlab::puppet_manage_packages {
+    package {'curl':
+      ensure => present,
+      before => Exec['download gitlab]',
+    }
   }
-  # Use wget to download gitlab
+  # Use curl to download gitlab
   exec { 'download gitlab':
-    command => "/usr/bin/wget ${gitlab_url}",
+    command => "/usr/bin/curl -o ${download_location}/${omnibus_filename} ${gitlab_url}",
     path    => '/usr/bin:/usr/sbin:/bin:/usr/local/bin:/usr/local/sbin',
-    cwd     => $download_location,
     creates => "${download_location}/${omnibus_filename}",
     timeout => 1800,
-    require => Package['wget'],
   }
   # Install gitlab with the appropriate package manager (rpm or dpkg)
   package { 'gitlab':

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -182,7 +182,7 @@ class gitlab::install inherits ::gitlab {
   if $::gitlab::puppet_manage_packages {
     package {'curl':
       ensure => present,
-      before => Exec['download gitlab]',
+      before => Exec['download gitlab'],
     }
   }
   # Use curl to download gitlab

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -179,12 +179,6 @@ class gitlab::install inherits ::gitlab {
   validate_string($download_location)
   info("omnibus_filename is \'${omnibus_filename}\'")
 
-  if $::gitlab::puppet_manage_packages {
-    package {'curl':
-      ensure => present,
-      before => Exec['download gitlab'],
-    }
-  }
   # Use curl to download gitlab
   exec { 'download gitlab':
     command => "/usr/bin/curl -o ${download_location}/${omnibus_filename} ${gitlab_url}",

--- a/manifests/packages.pp
+++ b/manifests/packages.pp
@@ -75,7 +75,7 @@ class gitlab::packages inherits ::gitlab {
     ensure => latest,
   }
   package {'curl':
-    ensure => present,
+    ensure => latest,
   }
   service { $mail_application:
     ensure  => running,

--- a/manifests/packages.pp
+++ b/manifests/packages.pp
@@ -74,6 +74,9 @@ class gitlab::packages inherits ::gitlab {
   package { $mail_application:
     ensure => latest,
   }
+  package {'curl':
+    ensure => present,
+  }
   service { $mail_application:
     ensure  => running,
     require => Package['openssh-server'],

--- a/manifests/packages.pp
+++ b/manifests/packages.pp
@@ -74,7 +74,7 @@ class gitlab::packages inherits ::gitlab {
   package { $mail_application:
     ensure => latest,
   }
-  package {'curl':
+  package { 'curl':
     ensure => latest,
   }
   service { $mail_application:


### PR DESCRIPTION
This patch changes two things in install.pp
 - Switches the download tool from wget to curl to allow the use of
   the 'file://' scheme for the download URL (wget doesn't support file://)
 - Checks $::gitlab::puppet_manage_packages before declaring
   Package['curl']. This follows the behaviour of the other dependencies
   and Puppet best practices.