### PR TITLE
Omnibus now includes GitLab CI

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -805,6 +805,20 @@ class gitlab (
 
   $high_availability_mountpoint = $::gitlab::params::high_availability_mountpoint,
 
+  #
+  # 6. GitLab CI customization
+  # ==========================
+
+  $ci_external_url         = $::gitlab::params::ci_external_url,
+  $gitlab_ci_email_from    = $::gitlab::params::gitlab_ci_email_from,
+  $gitlab_ci_support_email = $::gitlab::params::gitlab_ci_support_email,
+  $gitlab_server_urls      = $::gitlab::params::gitlab_server_urls,
+
+  $ci_redirect_http_to_https = $::gitlab::params::ci_redirect_http_to_https,
+  $ci_ssl_certificate        = $::gitlab::params::ci_ssl_certificate,
+  $ci_ssl_certificate_key    = $::gitlab::params::ci_ssl_certificate_key,
+  $ci_listen_addresses       = $::gitlab::params::ci_listen_addresses,
+
   ) inherits gitlab::params {
 
   # Verify required parameters are provided. 

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -199,4 +199,16 @@ class gitlab::params {
 
   $high_availability_mountpoint = undef # Prevents omnibus-gitlab services (nginx, redis, unicorn etc.) from starting before a given filesystem is mounted
 
+  #
+  # 6. GitLab CI customization
+  # ==========================
+  $ci_external_url         = undef
+  $gitlab_ci_email_from    = undef
+  $gitlab_ci_support_email = undef
+  $gitlab_server_urls      = undef
+
+  $ci_redirect_http_to_https = undef
+  $ci_ssl_certificate        = undef
+  $ci_ssl_certificate_key    = undef
+  $ci_listen_addresses       = undef
 }

--- a/templates/gitlab-puppet.rb.erb
+++ b/templates/gitlab-puppet.rb.erb
@@ -157,3 +157,18 @@ gitlab_rails['smtp_enable_starttls_auto'] = <%= @smtp_enable_starttls_auto %>
 <% end -%>
 <% if defined?(@high_availability_mountpoint) -%>high_availability['mountpoint'] = '<%= @high_availability_mountpoint %>'
 <% end %>
+#
+# 6. GitLab CI customization
+# ==========================
+<% if @ci_external_url -%>ci_external_url '<%= @ci_external_url %>'
+<% end %><% if @gitlab_ci_email_from -%>gitlab_ci['gitlab_ci_email_from'] = '<%= @gitlab_ci_email_from %>'
+<% end %><% if @gitlab_ci_support_email -%>gitlab_ci['gitlab_ci_support_email'] = '<%= @gitlab_ci_support_email %>'
+<% end %><% if @gitlab_server_urls -%>
+gitlab_ci['gitlab_server_urls'] = ["<%= @gitlab_server_urls.join('","') %>"]
+<% end %><% if @ci_redirect_http_to_https == true -%>
+ci_nginx['redirect_http_to_https'] = <%= @ci_redirect_http_to_https %>
+ci_nginx['ssl_certificate'] = '<%= @ci_ssl_certificate -%>'
+ci_nginx['ssl_certificate_key'] = '<%= @ci_ssl_certificate_key %>'
+<% end -%><% if @ci_listen_addresses -%>
+ci_nginx['listen_addresses'] = ["<%= @ci_listen_addresses.join('","') %>"]
+<% end %>


### PR DESCRIPTION
The omnibus packages now includes GitLab CI. It appears to be off by default, so doesn't cause any problems for this module. However, to take advantage of it, extra options will need to be made available to configure the CI bits in `/etc/gitlab/gitlab.rb`.

I'll be looking at this at some point so I'll produce a pull request if nobody else has done it by then.
