### PR TITLE
Add custom_hook support

### DIFF
--- a/README.md
+++ b/README.md
@@ -258,7 +258,40 @@ class { 'gitlab' :
 
 [Manage /etc/gitlab/gitlab.rb manually](https://gitlab.com/gitlab-org/omnibus-gitlab/blob/master/README.md)
 
+## Custom Hooks
 
+As of GitLab 7.5 and GitLab Shell 2.1.0, users can create custom `pre-receive`, `post-receive` and `update` hooks
+on the filesystem for each project. These hooks act just as normal server-side git hooks but are configured in
+a little different way by placing the file in `custom_hooks` instead of `hooks`.
+
+This module supports managing these custom hooks through a defined-type. A hook of each type (`pre-receive`,
+`post-receive` and `update`) can be created for each project in GitLab. See
+[GitLab Custom Hook documentation](https://github.com/gitlabhq/gitlabhq/blob/master/doc/hooks/custom_hooks.md)
+for more information.
+
+Pass the script contents as a string
+
+```puppet
+gitlab::custom_hook { 'project1_custom_hook':
+  namespace             => 'group1',
+  project               => 'my_project',
+  type                  => 'post-receive',
+  content               => "#!/bin/bash
+
+echo 'This is a post-receive hook!'",
+}
+```
+
+Pass a file as a source
+
+```puppet
+gitlab::custom_hook { 'project1_custom_hook':
+  namespace             => 'group1',
+  project               => 'my_project',
+  type                  => 'post-receive',
+  source                => 'puppet:///modules/my_module/post-receive',
+}
+```
 
 ###Enterprise
 

--- a/manifests/custom_hook.pp
+++ b/manifests/custom_hook.pp
@@ -1,0 +1,110 @@
+# == Define: gitlab::custom_hook
+#
+# Manage custom hook files within a GitLab project. Custom hooks can be created
+# as a pre-receive, post-receive, or update hook. It's possible to create
+# different custom hook types for the same project - one each for pre-receive,
+# post-receive and update.
+#
+# === Parameters
+#
+# [*namevar*]
+#   The namevar is arbitrary and is not used directly. Supply a descriptive
+#   namevar of your choosing.
+#
+# [*namespace*]
+#   The GitLab group namespace for the project.
+#
+# [*project*]
+#   The GitLab project name.
+#
+# [*type*]
+#   The custom hook type. Should be one of pre-receive, post-receive, or update.
+#
+# [*content*]
+#   Specify the custom hook contents either as a string or using the template
+#   function. If this paramter is specified source parameter must not be
+#   present.
+#
+# [*source*]
+#   Specify a file source path to populate the custom hook contents. If this
+#   paramter is specified content parameter must not be present.
+#
+# [*repos_path*]
+#   The GitLab shell repos path. This defaults to
+#   '/var/opt/gitlab/git-data/repositories' if not present.
+#
+# [*git_username*]
+#   The git user name. Defaults to 'git' if not present.
+#
+# [*git_groupname*]
+#   The git group name. Defaults to 'git' if not present.
+#
+#
+# === Examples
+#
+#   gitlab::custom_hook { 'my_custom_hook':
+#     namespace       => 'my_group',
+#     project         => 'my_project',
+#     type            => 'post-receive',
+#     source          => 'puppet:///modules/my_module/post-receive',
+#   }
+#
+# === Authors
+#
+# Drew A. Blessing <drew.blessing@mac.com>
+#
+# === Copyright
+#
+# Copyright 2014 Spencer Owen, unless otherwise noted.
+#
+define gitlab::custom_hook(
+  $namespace,
+  $project,
+  $type,
+  $content        = undef,
+  $source         = undef,
+  $repos_path     = '/var/opt/gitlab/git-data/repositories',
+  $git_username   = 'git',
+  $git_groupname  = 'git',
+) {
+  if $repos_path == undef {
+    $_repos_path = '/var/opt/gitlab/git-data/repositories'
+  } else {
+    $_repos_path = $repos_path
+  }
+
+  if !$content and !$source {
+    fail('gitlab::custom_hook resource must specify either content or source')
+  }
+
+  if $content and $source {
+    fail('gitlab::custom_hook resource must specify either content or source, but not both')
+  }
+
+  if $source {
+    validate_re($source, '^puppet:')
+  }
+
+  validate_re($type, '^(post-receive|pre-receive|update)$')
+
+  $hook_path = "${_repos_path}/${namespace}/${project}.git/custom_hooks"
+
+  File {
+    owner     => $git_username,
+    group     => $git_groupname,
+    mode      => '0755',
+  }
+
+  # Create the custom_hooks directory for this project, if it doesn't exist
+  if !defined(File[$hook_path]) {
+    file { $hook_path:
+      ensure      => directory,
+    }
+  }
+
+  file { "${hook_path}/${type}":
+    ensure      => 'present',
+    content     => $content,
+    source      => $source,
+  }
+}

--- a/spec/defines/custom_hook_spec.rb
+++ b/spec/defines/custom_hook_spec.rb
@@ -1,0 +1,156 @@
+require 'spec_helper'
+
+describe 'gitlab::custom_hook', :type => 'define' do
+  let(:facts) {
+    {
+      :puppetversion          => ENV['PUPPET_VERSION'],
+      :facterversion          => ENV['FACTER_VERSION'],
+      :osfamily               => 'RedHat',
+      :operatingsystem        => 'CentOS',
+      :operatingsystemrelease => '6.5',
+    }
+  }
+
+  context 'when neither $content and $source are defined' do
+    let(:title) { 'my_custom_hook' }
+    let(:params) {
+      {
+          :namespace      => 'my_group',
+          :project        => 'my_project',
+          :type           => 'pre-receive',
+      }
+    }
+
+    it do
+      expect { subject }.to raise_error(/gitlab::custom_hook resource must specify either content or source/)
+    end
+  end
+
+  context 'when $content and $source are defined' do
+    let(:title) { 'my_custom_hook' }
+    let(:params) {
+      {
+          :namespace      => 'my_group',
+          :project        => 'my_project',
+          :type           => 'pre-receive',
+          :content        => '#!/bin/bash',
+          :source         => 'puppet:///modules/my_module/pre-receive',
+      }
+    }
+
+    it do
+      expect { subject }.to raise_error(/gitlab::custom_hook resource must specify either content or source, but not both/)
+    end
+  end
+
+  context 'when $source is invalid' do
+    let(:title) { 'my_custom_hook' }
+    let(:params) {
+      {
+          :namespace      => 'my_group',
+          :project        => 'my_project',
+          :type           => 'pre-receive',
+          :source         => 'invalid_source_string',
+      }
+    }
+
+    it do
+      expect { subject }.to raise_error(/"invalid_source_string" does not match/)
+    end
+  end
+
+  context 'when $type is invalid' do
+    let(:title) { 'my_custom_hook' }
+    let(:params) {
+      {
+          :namespace      => 'my_group',
+          :project        => 'my_project',
+          :type           => 'receive',
+          :source         => 'puppet:///modules/my_module/pre-receive',
+      }
+    }
+
+    it do
+      expect { subject }.to raise_error(/"receive" does not match/)
+    end
+  end
+
+  context 'when $type is valid' do
+    context 'pre-receive' do
+      let(:title) { 'my_custom_hook' }
+      let(:params) {
+        {
+            :namespace      => 'my_group',
+            :project        => 'my_project',
+            :type           => 'pre-receive',
+            :source         => 'puppet:///modules/my_module/pre-receive',
+        }
+      }
+
+      it { expect { subject }.not_to raise_error }
+    end
+
+    context 'post-receive' do
+      let(:title) { 'my_custom_hook' }
+      let(:params) {
+        {
+            :namespace      => 'my_group',
+            :project        => 'my_project',
+            :type           => 'post-receive',
+            :source         => 'puppet:///modules/my_module/post-receive',
+        }
+      }
+
+      it { expect { subject }.not_to raise_error }
+    end
+
+    context 'update' do
+      let(:title) { 'my_custom_hook' }
+      let(:params) {
+        {
+            :namespace      => 'my_group',
+            :project        => 'my_project',
+            :type           => 'update',
+            :source         => 'puppet:///modules/my_module/update',
+        }
+      }
+
+      it { expect { subject }.not_to raise_error }
+    end
+  end
+
+  context 'when valid' do
+    context '$source' do
+      let(:title) { 'my_custom_hook' }
+      let(:params) {
+        {
+            :namespace      => 'my_group',
+            :project        => 'my_project',
+            :type           => 'pre-receive',
+            :source         => 'puppet:///modules/my_module/pre-receive',
+        }
+      }
+
+      it do
+        should contain_file('/var/opt/gitlab/git-data/repositories/my_group/my_project.git/custom_hooks/pre-receive')
+      end
+    end
+
+    context '$content' do
+      let(:title) { 'my_custom_hook' }
+      let(:params) {
+        {
+            :namespace      => 'my_group',
+            :project        => 'my_project',
+            :type           => 'post-receive',
+            :content        => '#!/bin/bash'
+        }
+      }
+
+      it do
+        should contain_file('/var/opt/gitlab/git-data/repositories/my_group/my_project.git/custom_hooks/post-receive')
+          .with_content('#!/bin/bash')
+      end
+    end
+  end
+end

--- a/tests/custom_hook.pp
+++ b/tests/custom_hook.pp
@@ -1,0 +1,17 @@
+# This example will result in the contents of the source file being placed
+# in /var/opt/gitlab/git-data/repositories/my_group/my_project.git/custom_hooks/post-receive
+gitlab::custom_hook { 'my_custom_hook':
+  namespace       => 'my_group',
+  project         => 'my_project',
+  type            => 'post-receive',
+  source          => 'puppet:///modules/my_module/post-receive',
+}
+
+# This example will result in the contents of the template being placed
+# in /var/opt/gitlab/git-data/repositories/my_group/my_project.git/custom_hooks/pre-receive
+gitlab::custom_hook { 'my_custom_pre_receive_hook':
+  namespace       => 'my_group',
+  project         => 'my_project',
+  type            => 'pre-receive',
+  content         => template('my_module/pre-receive.erb'),
+}


### PR DESCRIPTION
This PR fixes #103 and adds support for GitLab custom hooks.

The support is fully tested and works as advertised. Documentation was added in the `README.md`
