### PR TITLE
Add support for mysql in GitLab CI

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -616,6 +616,58 @@
 #     Prevents omnibus-gitlab services (nginx, redis, unicorn etc.) from starting before a given filesystem is mounted
 #     Example: '/tmp'
 #
+# 6. CI customization
+# ==========================
+#
+# [*ci_db_encoding*]
+#     default => undef
+#     The database encoding. Only available if `postgresql_enable` is false
+#     or `mysql_enable` is true.
+#     Example: 'unicode'
+#
+# [*ci_db_database*]
+#     default => undef
+#     The database name. Only available if `postgresql_enable` is false
+#     or `mysql_enable` is true.
+#     Example: 'gitlabci_production'
+#
+# [*ci_db_pool*]
+#     default => 10
+#     The database pool size. Only available if `postgresql_enable` is false
+#     or `mysql_enable` is true.
+#     Example: 20
+#
+# [*ci_db_username*]
+#     default => 'git'
+#     The database username. Only available if `postgresql_enable` is false
+#     or `mysql_enable` is true.
+#     Example: 'gitlab_ci'
+#
+# [*ci_db_password*]
+#     default => undef
+#     The database password. Only available if `postgresql_enable` is false
+#     or `mysql_enable` is true.
+#     Example: 'secret_password'
+#
+# [*ci_db_host*]
+#     default => undef
+#     The database hostname. Only available if `postgresql_enable` is false
+#     or `mysql_enable` is true.
+#     Example: '127.0.0.1'
+#
+# [*ci_db_socket*]
+#     default => undef
+#     Specify a database socket to use instead of a port. Only available if
+#     `postgresql_enable` is false or `mysql_enable` is true.
+#     Example: 'unix://path/to/db/socket.sock'
+#
+# [*ci_db_port*]
+#     default => undef
+#     The database port. This value must be set to match `postgresql_port` if
+#     that value is changed,
+#     Example: 5432
+#
+#
 # === Examples
 #
 # Basic Example with https
@@ -820,12 +872,22 @@ class gitlab (
   $ci_external_url         = $::gitlab::params::ci_external_url,
   $gitlab_ci_email_from    = $::gitlab::params::gitlab_ci_email_from,
   $gitlab_ci_support_email = $::gitlab::params::gitlab_ci_support_email,
-  $gitlab_server_urls      = $::gitlab::params::gitlab_server_urls,
+  $gitlab_server           = $::gitlab::params::gitlab_server,
 
   $ci_redirect_http_to_https = $::gitlab::params::ci_redirect_http_to_https,
   $ci_ssl_certificate        = $::gitlab::params::ci_ssl_certificate,
   $ci_ssl_certificate_key    = $::gitlab::params::ci_ssl_certificate_key,
   $ci_listen_addresses       = $::gitlab::params::ci_listen_addresses,
+
+  $ci_db_adapter         = $::gitlab::params::ci_db_adapter,
+  $ci_db_encoding        = $::gitlab::params::ci_db_encoding,
+  $ci_db_database        = $::gitlab::params::ci_db_database,
+  $ci_db_username        = $::gitlab::params::ci_db_username,
+  $ci_db_password        = $::gitlab::params::ci_db_password,
+  $ci_db_pool            = $::gitlab::params::ci_db_pool,
+  $ci_db_host            = $::gitlab::params::ci_db_host,
+  $ci_db_port            = $::gitlab::params::ci_db_port,
+  $ci_db_socket          = $::gitlab::params::ci_db_socket,
 
   ) inherits gitlab::params {
 
@@ -929,6 +991,12 @@ class gitlab (
     or $db_password or $db_host or $db_socket)
     and ($postgresql_enable == undef or $postgresql_enable or !$mysql_enable) {
     fail('db_adapter, db_encoding, db_database, db_pool, db_username, db_password, db_host, and db_socket cannot be set unless postgres_enable is false or mysql_enable is true')
+  }
+
+  if ($ci_db_adapter or $ci_db_encoding or $ci_db_database or $ci_db_pool or $ci_db_username
+    or $ci_db_password or $ci_db_host or $ci_db_socket)
+    and ($postgresql_enable == undef or $postgresql_enable or !$mysql_enable) {
+    fail('ci_db_adapter, ci_db_encoding, ci_db_database, ci_db_pool, ci_db_username, ci_db_password, ci_db_host, and ci_db_socket cannot be set unless postgres_enable is false or mysql_enable is true')
   }
 
   if $postgresql_port and !$db_port {

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -207,10 +207,20 @@ class gitlab::params {
   $ci_external_url         = undef
   $gitlab_ci_email_from    = undef
   $gitlab_ci_support_email = undef
-  $gitlab_server_urls      = undef
+  $gitlab_server           = undef
 
   $ci_redirect_http_to_https = undef
   $ci_ssl_certificate        = undef
   $ci_ssl_certificate_key    = undef
   $ci_listen_addresses       = undef
+
+  $ci_db_adapter         = undef # (default: 'postgresql')
+  $ci_db_encoding        = undef # (default: 'unicode')
+  $ci_db_database        = undef # (default: 'gitlab_ci_production')
+  $ci_db_pool            = undef # (default: 10)
+  $ci_db_username        = undef # (default: 'gitlab_ci')
+  $ci_db_password        = undef # (default: nil)
+  $ci_db_host            = undef # (default: nil)
+  $ci_db_port            = undef # (default: 5432)
+  $ci_db_socket          = undef # (default: nil)
 }

--- a/templates/gitlab-puppet.rb.erb
+++ b/templates/gitlab-puppet.rb.erb
@@ -164,9 +164,21 @@ gitlab_rails['smtp_enable_starttls_auto'] = <%= @smtp_enable_starttls_auto %>
 <% if @ci_external_url -%>ci_external_url '<%= @ci_external_url %>'
 <% end %><% if @gitlab_ci_email_from -%>gitlab_ci['gitlab_ci_email_from'] = '<%= @gitlab_ci_email_from %>'
 <% end %><% if @gitlab_ci_support_email -%>gitlab_ci['gitlab_ci_support_email'] = '<%= @gitlab_ci_support_email %>'
-<% end %><% if @gitlab_server_urls -%>
-gitlab_ci['gitlab_server_urls'] = ["<%= @gitlab_server_urls.join('","') %>"]
-<% end %><% if @ci_redirect_http_to_https == true -%>
+<% end %><% if @gitlab_server -%>
+gitlab_ci['gitlab_server'] = <%= @gitlab_server %>
+<% end -%>
+<% if @postgresql_enable == false || @mysql_enable == true -%>
+<% if @ci_db_adapter -%>gitlab_ci['db_adapter'] = '<%= @ci_db_adapter %>'
+<% end %><% if @ci_db_encoding %>gitlab_ci['db_encoding'] = '<%= @ci_db_encoding %>'
+<% end %><% if @ci_db_database -%>gitlab_ci['db_database'] = '<%= @ci_db_database %>'
+<% end %><% if @ci_db_pool -%>gitlab_ci['db_pool'] = <%= @ci_db_pool %>
+<% end %><% if @ci_db_username -%>gitlab_ci['db_username'] = '<%= @ci_db_username %>'
+<% end %><% if @ci_db_password -%>gitlab_ci['db_password'] = '<%= @ci_db_password %>'
+<% end %><% if @ci_db_host -%>gitlab_ci['db_host'] = '<%= @ci_db_host %>'
+<% end %><% if @ci_db_socket -%>gitlab_ci['db_socket'] = <%= @ci_mysql_socket %>
+<% end %><% if @ci_db_port -%>gitlab_ci['db_port'] = '<%= @ci_db_port %>'
+<% end -%>
+<% if @ci_redirect_http_to_https == true -%>
 ci_nginx['redirect_http_to_https'] = <%= @ci_redirect_http_to_https %>
 ci_nginx['ssl_certificate'] = '<%= @ci_ssl_certificate -%>'
 ci_nginx['ssl_certificate_key'] = '<%= @ci_ssl_certificate_key %>'


### PR DESCRIPTION
Add support for MySQL with GitLab CI (for Enterprise only).

This also updates `gitlab_server_url` to `gitlab_server` (due to new oAuth between GitLab and GitLab CI). 