### PR TITLE
Issue110

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,8 @@ Supported Operating Systems:
 - Debian 7.5
 - Ubuntu 12.04
 - Ubuntu 14.04
-
+- Oracle Linux 6.5
+- Oracle Linux 7
 
 ##Usage
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -46,6 +46,10 @@ Vagrant.configure("2") do |config|
     debianbox.vm.box_url = "http://puppet-vagrant-boxes.puppetlabs.com/debian-73-x64-virtualbox-puppet.box"
   end
 
-
+  # Oracle Linux 6.5
+  config.vm.define "oraclelinux6", autostart: false do |oraclelinuxbox|
+    oraclelinuxbox.vm.box = "oraclelinux-6_5-x64-virtualbox_4_3-plain"
+    oraclelinuxbox.vm.box_url = "https://storage.us2.oraclecloud.com/v1/istoilis-istoilis/vagrant/oel65-64.box"
+  end
   
 end

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -35,9 +35,10 @@ class gitlab::install inherits ::gitlab {
   # Set variables to make it easy to define $gitlab_url 
   case $::osfamily {
     'Debian': {
-      $omnibus_release = 'omnibus-1_amd64.deb'
-      $url_separator   = '_' #some urls are gitlab-7.0.0 others gitlab_7.0.0
-      $package_manager = 'dpkg'
+      $omnibus_release           = 'omnibus-1_amd64.deb'
+      $url_separator             = '_' #some urls are gitlab-7.0.0 others gitlab_7.0.0
+      $package_manager           = 'dpkg'
+      $operatingsystem_lowercase = downcase($::operatingsystem)
 
         case $::gitlab::gitlab_release {
           'basic' : {
@@ -86,9 +87,10 @@ class gitlab::install inherits ::gitlab {
       info("RedHat major version is ${cent_maj_version}")
 
       # The default rpm name if user doesn't specify $gitlab_download_link
-      $omnibus_release = "omnibus-1.el${cent_maj_version}.x86_64.rpm"
-      $url_separator   = '-' #some urls are gitlab-7.0.0 others gitlab_7.0.0
-      $package_manager = 'rpm'
+      $omnibus_release           = "omnibus-1.el${cent_maj_version}.x86_64.rpm"
+      $url_separator             = '-' #some urls are gitlab-7.0.0 others gitlab_7.0.0
+      $package_manager           = 'rpm'
+      $operatingsystem_lowercase = 'centos'
 
         case $::gitlab::gitlab_release {
           'basic' : {
@@ -133,8 +135,6 @@ class gitlab::install inherits ::gitlab {
         # User did not set $gitlab_release, assume basic
         warning("\$gitlab_release is undefined, yet \$gitlab_download_link is set, assuming gitlab basic")
         info("\$Downloading ${::gitlab::gitlab_release} from user specified url: ${::gitlab::gitlab_download_link}")
-        # $operatingsystem_lowercase = downcase($::operatingsystem)
-        $operatingsystem_lowercase=downcase($::operatingsystem)
         $gitlab_url = "${download_prefix}/${operatingsystem_lowercase}-${::operatingsystemrelease}/${omnibus_filename}"
       }
       'basic' : {
@@ -160,7 +160,6 @@ class gitlab::install inherits ::gitlab {
         # Basic version, use default derived url. This is the most common configuration
         info("\$gitlab_release is \'${::gitlab::gitlab_release}\' and \$gitlab_download_link is \'${::gitlab::gitlab_download_link}\'")
         # e.g. https://foo/bar/ubuntu-12.04/gitlab_7.0.0-omnibus-1_amd64.deb 
-        $operatingsystem_lowercase = downcase($::operatingsystem)
         $gitlab_url = "${download_prefix}/${operatingsystem_lowercase}-${::operatingsystemrelease}/${omnibus_filename}"
         info("Downloading from default url ${gitlab_url}")
       }

--- a/manifests/packages.pp
+++ b/manifests/packages.pp
@@ -21,7 +21,7 @@ class gitlab::packages inherits ::gitlab {
   # The install documentation recommends different mail apps for different releases
   # https://about.gitlab.com/downloads/
   case $::operatingsystem {
-    'CentOS': {
+    'CentOS', 'OracleLinux': {
       $mail_application = 'postfix'
       $ssh_service_name = 'sshd'
       
@@ -49,7 +49,7 @@ class gitlab::packages inherits ::gitlab {
             }
         }
         default: {
-          fail("Only CentOS 6 and 7 are presently supported, found: ${::osfamily}-${::operatingsystem}-${::operatingsystemrelease} ")
+          fail("Only CentOS/OracleLinux 6 and 7 are presently supported, found: ${::osfamily}-${::operatingsystem}-${::operatingsystemrelease} ")
         }
       }
     }
@@ -64,7 +64,7 @@ class gitlab::packages inherits ::gitlab {
 
     }
     default: {
-      fail("Only CentOS, Ubuntu and Debian presently supported, found \'${::osfamily}\':\'${::operatingsystem}\'-\'${::operatingsystemrelease}\' ")
+      fail("Only CentOS/OracleLinux, Ubuntu and Debian presently supported, found \'${::osfamily}\':\'${::operatingsystem}\'-\'${::operatingsystemrelease}\' ")
     }
   }
 

--- a/metadata.json
+++ b/metadata.json
@@ -33,7 +33,15 @@
             "operatingsystemrelease": [
                 "7"
             ]
+        },
+        {
+            "operatingsystem": "OracleLinux",
+            "operatingsystemrelease": [
+                "6.5",
+                "7"
+            ]
         }
+
     ]
 
 }

--- a/spec/classes/gitlab_spec.rb
+++ b/spec/classes/gitlab_spec.rb
@@ -203,7 +203,7 @@ describe 'gitlab', :type => 'class' do
       }
     }
     it do
-      expect { subject }.to raise_error(/Only CentOS 6 and 7 are presently supported, found:/)
+      expect { subject }.to raise_error(/Only CentOS\/OracleLinux 6 and 7 are presently supported, found:/)
     end
   end
 


### PR DESCRIPTION
Added OracleLinux support in packages.pp, also updated the fail messages. The existing test was also updated in gitlab_spec.rb.
The changes in install.pp ensure that the install package for Centos is downloaded (there is no separate OracleLinux install package). Only works for Gitlab version 7.4.3 and lower (see #100).

