### PR TITLE
disable cron output when the backup was executed successfully

### DIFF
--- a/manifests/backup.pp
+++ b/manifests/backup.pp
@@ -27,7 +27,7 @@ class gitlab::backup inherits ::gitlab {
 
   # Execute rake backup every night at 2 am
   cron { 'gitlab-backup':
-    command => '/opt/gitlab/bin/gitlab-rake gitlab:backup:create',
+    command => 'CRON=1 /opt/gitlab/bin/gitlab-rake gitlab:backup:create',
     user    => root,
     hour    => 2,
     minute  => 0,


### PR DESCRIPTION
We do not want noisy cron output if everything went fine,
see also https://gitlab.com/gitlab-org/gitlab-ce/blob/master/doc/raketasks/backup_restore.md#configure-cron-to-make-daily-backups