### PR TITLE
Use maestrodev/wget

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -22,6 +22,8 @@
 #
 class gitlab::install inherits ::gitlab {
 
+  require wget
+
   # Sets the download url. Examples for gitlab basic
   # https://downloads-packages.s3.amazonaws.com/centos-6.5/gitlab-7.0.0_omnibus-1.el6.x86_64.rpm
   # https://downloads-packages.s3.amazonaws.com/debian-7.5/gitlab_7.0.0-omnibus-1_amd64.deb
@@ -178,9 +180,6 @@ class gitlab::install inherits ::gitlab {
   validate_string($download_location)
   info("omnibus_filename is \'${omnibus_filename}\'")
 
-  package {'wget':
-    ensure  => present,
-  }
   # Use wget to download gitlab
   exec { 'download gitlab':
     command => "/usr/bin/wget ${gitlab_url}",
@@ -188,7 +187,6 @@ class gitlab::install inherits ::gitlab {
     cwd     => $download_location,
     creates => "${download_location}/${omnibus_filename}",
     timeout => 1800,
-    require => Package['wget'],
   }
   # Install gitlab with the appropriate package manager (rpm or dpkg)
   package { 'gitlab':

--- a/metadata.json
+++ b/metadata.json
@@ -1,47 +1,49 @@
 {
-    "name": "spuder-gitlab",
-    "version": "2.3.5",
-    "summary": "Installs and configures gitlab 7 using omnibus installer",
-    "author": "Spencer Owen",
-    "dependencies": [ { "name": "puppetlabs/stdlib", "version_requirement": ">=3.0.0" } ],
-    "source": "https://github.com/spuder/puppet-gitlab",
-    "project_page": "https://github.com/spuder/puppet-gitlab/blob/master/README.md",
-    "license": "GPLv3",
-    "requirements": [
-        {
-            "name": "puppet",
-            "version_requirement": "3.x"
-        }
-    ],
-    "operatingsystem_support": [
-        {
-            "operatingsystem": "RedHat",
-            "operatingsystemrelease": [
-                "6",
-                "7"
-            ]
-        },
-        {
-            "operatingsystem": "Ubuntu",
-            "operatingsystemrelease": [
-                "12.04",
-                "14.04"
-            ]
-        },
-        {
-            "operatingsystem": "Debian",
-            "operatingsystemrelease": [
-                "7"
-            ]
-        },
-        {
-            "operatingsystem": "OracleLinux",
-            "operatingsystemrelease": [
-                "6.5",
-                "7"
-            ]
-        }
-
-    ]
-
+  "name": "spuder-gitlab",
+  "version": "2.3.5",
+  "author": "Spencer Owen",
+  "summary": "Installs and configures gitlab 7 using omnibus installer",
+  "license": "GPLv3",
+  "source": "https://github.com/spuder/puppet-gitlab",
+  "project_page": "https://github.com/spuder/puppet-gitlab/blob/master/README.md",
+  "issues_url": "https://github.com/spuder/puppet-gitlab/issues",
+  "requirements": [
+    {
+      "name": "puppet",
+      "version_requirement": "3.x"
+    }
+  ],
+  "operatingsystem_support": [
+    {
+      "operatingsystem": "RedHat",
+      "operatingsystemrelease": [
+        "6",
+        "7"
+      ]
+    },
+    {
+      "operatingsystem": "Ubuntu",
+      "operatingsystemrelease": [
+        "12.04",
+        "14.04"
+      ]
+    },
+    {
+      "operatingsystem": "Debian",
+      "operatingsystemrelease": [
+        "7"
+      ]
+    },
+    {
+      "operatingsystem": "OracleLinux",
+      "operatingsystemrelease": [
+        "6.5",
+        "7"
+      ]
+    }
+  ],
+  "dependencies": [
+    {"name":"puppetlabs/stdlib","version_requirement":">=3.0.0"},
+    {"name":"maestrodev/wget","version_requirement":">=1.1.0"}
+  ]
 }


### PR DESCRIPTION
Without this patch, you cannot use this module if you have wget
previously declared. This uses maestrodev/wget which is a Puppet Labs
Approved module.