### PR TITLE
Generic MTA support and Debian omnibus version fix

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -35,7 +35,7 @@ class gitlab::install inherits ::gitlab {
   # Set variables to make it easy to define $gitlab_url 
   case $::osfamily {
     'Debian': {
-      $omnibus_release           = 'omnibus-1_amd64.deb'
+      $omnibus_release           = 'omnibus.1-1_amd64.deb'
       $url_separator             = '_' #some urls are gitlab-7.0.0 others gitlab_7.0.0
       $package_manager           = 'dpkg'
       $operatingsystem_lowercase = downcase($::operatingsystem)

--- a/templates/gitlab-puppet.rb.erb
+++ b/templates/gitlab-puppet.rb.erb
@@ -141,8 +141,8 @@ gitlab_rails['aws_region'] = '<%= @aws_region %>'
 gitlab_rails['smtp_enable'] = <%= @smtp_enable %>
 gitlab_rails['smtp_address'] = '<%= @smtp_address %>'
 gitlab_rails['smtp_port'] = <%= @smtp_port %>
-gitlab_rails['smtp_user_name'] = '<%= @smtp_user_name %>'
-gitlab_rails['smtp_password'] = '<%= @smtp_password %>'
+gitlab_rails['smtp_user_name'] = <% if @smtp_user_name %>'<%= @smtp_user_name %>'<% else %>nil<% end %>
+gitlab_rails['smtp_password'] = <% if @smtp_password %>'<%= @smtp_password %>'<% else %>nil<% end %>
 gitlab_rails['smtp_domain'] = '<%= @smtp_domain %>'
 gitlab_rails['smtp_authentication'] = '<%= @smtp_authentication %>'
 gitlab_rails['smtp_enable_starttls_auto'] = <%= @smtp_enable_starttls_auto %>


### PR DESCRIPTION
Hi,

I have made the 2 fixes below. One was related to the changed omnibus version for Debian. It now contains additional level of numbering. Maybe it should become a Debian specific parameter...

The top level change is more important as it allows configuring the SMTP in a more generic way and allows running gitlab iwth a local MTA that listens on 127.0.0.1. As a side effect this allows using e.g. exim4 instead of the default postfix etc.

Let me know if I need to clarify anything else.

Best regards,

Jan