### PR TITLE
custom_appearances_helper - initial implementation

### DIFF
--- a/manifests/custom_appearances_helper.pp
+++ b/manifests/custom_appearances_helper.pp
@@ -1,0 +1,48 @@
+# == Class: gitlab::custom_appearances_helper
+#
+# This class deploys custom appearances helper. This can be used to
+# customize the look of the sign-in screen.
+#
+# === Parameters
+#
+# [*brand_image*]
+#   Path where the brand image can be fetched
+# [*brand_title*]
+#   Title for the main page
+# [*brand_text*]
+#   Customization that appears next to the brand logo (brand_image)
+# [*module_pathname*]
+#   Path where the appearances module is being stored (default for
+#   omnibus package provided)
+#
+# === Examples
+#
+# class { 'gitlab::custom_appearances_helper':
+#   brand_title => 'GitLab for Example.org',
+#   brand_image => 'http://www.gravatar.com/avatar/0?s=200&d=mm',
+#   brand_text  => 'Example.org is a software development group',
+# }
+#
+# === Authors
+#
+# Braiins Systems s.r.o.
+#
+# === Copyright
+#
+# Copyright 2015 Braiins Systems s.r.o.
+#
+class gitlab::custom_appearances_helper (
+  $brand_title=undef,
+  $brand_image=undef,
+  $brand_text=undef,
+  $module_pathname='/opt/gitlab/embedded/service/gitlab-rails/app/helpers/appearances_helper.rb',
+  ) {
+
+  file { $module_pathname :
+    ensure  => present,
+    owner   => root,
+    group   => root,
+    content => template('gitlab/appearances_helper.rb.erb'),
+    notify  => Exec['/usr/bin/gitlab-ctl reconfigure'],
+  }
+}

--- a/templates/appearances_helper.rb.erb
+++ b/templates/appearances_helper.rb.erb
@@ -1,0 +1,18 @@
+# This module has been deployed by puppet for <%= @fqdn %>
+module AppearancesHelper
+  def brand_item
+    <% if @brand_image || @brand_text %>true<% else %>false<% end %>
+  end
+
+  def brand_title
+    <%if @brand_title %>'<%= @brand_title %>'<% else %>nil<% end %>
+  end
+
+  def brand_image
+    <%if @brand_image %>image_tag '<%= @brand_image %>'<% else %>nil<% end %>
+  end
+
+  def brand_text
+    <%if @brand_text %>'<%= @brand_text %>'<% else %>nil<% end %>
+  end
+end


### PR DESCRIPTION
Hi,

would you include the following class that allows customizations of the sign-in page? I have find out that the extra_sign_in_text option:
- doesn't seem to work in CE edition 7.8.2
- it would still leave some generic text as can be seen in ```/opt/gitlab/embedded/service/gitlab-rails/app/views/layouts/devise.html.haml```

The new class simply deploys a custom appearance helper (I deploy it simply after the main gitlab class) as follows:
```
  class { 'gitlab' : 
    puppet_manage_config            => true,
    puppet_manage_backups           => true,
    puppet_manage_packages          => false,
    gitlab_branch                   => '7.8.2',
    external_url                    => 'http://gitlab.example.org',
  } ->
  class { 'gitlab::custom_appearances_helper':
    brand_title => 'Braiins GitLab',
    brand_image => 'http://www.gravatar.com/avatar/4d358f7a202bff084b04851eee7f957b?s=200',
  }
```
I know this maybe a bit controversial as it makes the CE edition branded. The comfort of setting this up is still not as good as in the enterprise edition so it shouldn't matter that much.

Let me know, if you don't like it - I would create a separate module for it or leave it in my separate branch. I just still think it wonderfully extends your modules functionality.

Best regards,

Jan

```
