### PR TITLE
backup_upload_remote_directory needs to be put into single quotes in gitlab.rb

### DIFF
--- a/templates/gitlab-puppet.rb.erb
+++ b/templates/gitlab-puppet.rb.erb
@@ -74,7 +74,7 @@ gitlab_rails['ldap_admin_group'] = '<%= @ldap_admin_group %>'
 <% end %><% if @backup_path      -%>gitlab_rails['backup_path'] = '<%= @backup_path %>'
 <% end %><% if @backup_keep_time -%>gitlab_rails['backup_keep_time'] = <%= @backup_keep_time %>
 <% end %><% if @backup_upload_connection -%>gitlab_rails['backup_upload_connection'] = <%= @backup_upload_connection %>
-<% end %><% if @backup_upload_remote_directory -%>gitlab_rails['backup_upload_remote_directory'] = <%= @backup_upload_remote_directory %>
+<% end %><% if @backup_upload_remote_directory -%>gitlab_rails['backup_upload_remote_directory'] = '<%= @backup_upload_remote_directory %>'
 <% end %><% if @gitlab_shell_path            -%>gitlab_rails['gitlab_shell_path'] = '<%= @gitlab_shell_path %>'
 <% end %><% if @gitlab_shell_repos_path      -%>gitlab_rails['gitlab_shell_repos_path'] = '<%= @gitlab_shell_repos_path %>'
 <% end %><% if @gitlab_shell_hooks_path      -%>gitlab_rails['gitlab_shell_hooks_path'] = '<%= @gitlab_shell_hooks_path %>'


### PR DESCRIPTION
If backup_upload_remote_directory is not put into single quotes, it can cause issues with GitLab like this:
Notice: /Stage[main]/Gitlab::Config/Exec[/usr/bin/gitlab-ctl reconfigure]/returns: NoMethodError
Notice: /Stage[main]/Gitlab::Config/Exec[/usr/bin/gitlab-ctl reconfigure]/returns: -------------
Notice: /Stage[main]/Gitlab::Config/Exec[/usr/bin/gitlab-ctl reconfigure]/returns: undefined method `example' for nil:NilClass

(that is an example where backup_upload_remote_directory is set to 'gitlab.example.com-backup' (S3 bucket).