### PR TITLE
Check if wget is previously installed

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -178,9 +178,10 @@ class gitlab::install inherits ::gitlab {
   validate_string($download_location)
   info("omnibus_filename is \'${omnibus_filename}\'")
 
-  package {'wget':
-    ensure  => present,
+  if ! defined(Package['wget']) {
+    package { 'wget': ensure => present }
   }
+  
   # Use wget to download gitlab
   exec { 'download gitlab':
     command => "/usr/bin/wget ${gitlab_url}",


### PR DESCRIPTION
This prevents the error when wget is managed by another class:
Error: Duplicate declaration: Package[wget] is already declared; cannot redeclare at /etc/puppet/modules/gitlab/manifests/install.pp:183

This will solve this issue: https://github.com/spuder/puppet-gitlab/issues/132