### PR TITLE
Backup scheduling parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -376,7 +376,27 @@ irc     => spuder
 # [*puppet_manage_backups*]
 #   default => true
 #   Includes backup.pp which sets cron job to run rake task
-# 
+#
+# [*backup_hour*]
+#   default => 2
+#   The hour at which to run the backup rake task
+#
+# [*backup_minute*]
+#   default => 0
+#   The minute at which to run the backup rake task
+#
+# [*backup_month*]
+#   default => undef
+#   The month of the year in which to run the backup rake task
+#
+# [*backup_monthday*]
+#   default => undef
+#   The day of the month on which to run the backup rake task
+#
+# [*backup_weekday*]
+#   default => undef
+#   The weekday on which to run the backup rake task
+#
 # [*puppet_manage_packages*]
 #   default => true
 #   Includes packages.pp which installs postfix and openssh

--- a/manifests/backup.pp
+++ b/manifests/backup.pp
@@ -1,8 +1,8 @@
 # == Class: gitlab::backup
 #
-#  Optional Class, creates cron job to backup gitlab at 2 am every night.
-#  Set $gitlab_manage_backups to 'false' in class declaration if you wish to 
-#  manually manage backups
+#  Optional Class, creates cron job to backup gitlab. The time can be
+#  specified with a set of variables. Set $gitlab_manage_backups to
+#  'false' in class declaration if you wish to manually manage backups.
 #
 # === Parameters
 #
@@ -23,14 +23,23 @@
 #
 # Copyright 2014 Spencer Owen, unless otherwise noted.
 #
-class gitlab::backup inherits ::gitlab {
+class gitlab::backup (
+  $backup_hour     = 2,
+  $backup_minute   = 0,
+  $backup_month    = undef,
+  $backup_monthday = undef,
+  $backup_weekday  = undef,
+) inherits ::gitlab {
 
-  # Execute rake backup every night at 2 am
+  # Execute rake backup
   cron { 'gitlab-backup':
-    command => 'CRON=1 /opt/gitlab/bin/gitlab-rake gitlab:backup:create',
-    user    => root,
-    hour    => 2,
-    minute  => 0,
+    command  => 'CRON=1 /opt/gitlab/bin/gitlab-rake gitlab:backup:create',
+    user     => root,
+    hour     => $backup_hour,
+    minute   => $backup_minute,
+    month    => $backup_month,
+    monthday => $backup_monthday,
+    weekday  => $backup_weekday,
   }
 
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -795,6 +795,11 @@ class gitlab (
 
   $backup_path                 = $::gitlab::params::backup_path,
   $backup_keep_time            = $::gitlab::params::backup_keep_time,
+  $backup_hour                 = $::gitlab::params::backup_hour,
+  $backup_minute               = $::gitlab::params::backup_minute,
+  $backup_month                = $::gitlab::params::backup_month,
+  $backup_monthday             = $::gitlab::params::backup_monthday,
+  $backup_weekday              = $::gitlab::params::backup_weekday,
   $backup_upload_connection    = $::gitlab::params::backup_upload_connection,
   $backup_upload_remote_directory = $::gitlab::params::backup_upload_remote_directory,
   $gitlab_shell_path           = $::gitlab::params::gitlab_shell_path,
@@ -989,7 +994,15 @@ class gitlab (
   if $puppet_manage_backups == true {
     notice('Puppet will manage backups because $puppet_manage_backups is true')
     include ::gitlab::install
-    include ::gitlab::backup
+
+    class { '::gitlab::backup':
+      backup_hour     => $backup_hour,
+      backup_minute   => $backup_minute,
+      backup_month    => $backup_month,
+      backup_monthday => $backup_monthday,
+      backup_weekday  => $backup_weekday,
+    }
+
     Class['::gitlab::install'] -> Class['::gitlab::backup']
   }
   else {

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -122,7 +122,13 @@ class gitlab::params {
 
   $backup_path                 = undef # '/var/opt/gitlab/backups'   # Relative paths are relative to Rails.root (default: tmp/backups/)
   $backup_keep_time            = undef # default: 0 (forever) (in seconds), 604800 = 1 week
-  
+
+  $backup_hour                 = 2
+  $backup_minute               = 0
+  $backup_month                = undef
+  $backup_monthday             = undef
+  $backup_weekday              = undef
+
   $backup_upload_connection    = undef # Backup to fog http://bit.ly/1t5nAv5
   $backup_upload_remote_directory = undef # Where to store backups in fog http://bit.ly/1t5nAv5
   $gitlab_shell_path           = undef # '/opt/gitlab/embedded/service/gitlab-shell/'

--- a/spec/classes/gitlab_backup_spec.rb
+++ b/spec/classes/gitlab_backup_spec.rb
@@ -9,6 +9,11 @@ describe 'gitlab', :type => 'class' do
         :gitlab_branch         => '7.2.0',
         :external_url          => 'http://gitlab.example.com',
         :puppet_manage_backups => true,
+        :backup_hour           => 2,
+        :backup_minute         => 0,
+        :backup_month          => 1,
+        :backup_monthday       => 1,
+        :backup_weekday        => 1,
       }
     }
     let(:facts) {
@@ -52,6 +57,11 @@ describe 'gitlab', :type => 'class' do
         :external_url     => 'http://gitlab.example.com',
         :backup_upload_connection => 'foobar',
         :puppet_manage_backups => true,
+        :backup_hour           => 2,
+        :backup_minute         => 0,
+        :backup_month          => 1,
+        :backup_monthday       => 1,
+        :backup_weekday        => 1,
       }
     }
     let(:facts) {
@@ -76,6 +86,11 @@ describe 'gitlab', :type => 'class' do
         :external_url     => 'http://gitlab.example.com',
         :backup_upload_remote_directory => 'foobar',
         :puppet_manage_backups => true,
+        :backup_hour           => 2,
+        :backup_minute         => 0,
+        :backup_month          => 1,
+        :backup_monthday       => 1,
+        :backup_weekday        => 1,
       }
     }
     let(:facts) {
@@ -91,6 +106,4 @@ describe 'gitlab', :type => 'class' do
       should contain_file('/etc/gitlab/gitlab.rb').with_content(/backup_upload_remote_directory/)
     end
   end
-
-
 end

--- a/tests/all_parameters_enabled.pp
+++ b/tests/all_parameters_enabled.pp
@@ -153,6 +153,11 @@ class { 'gitlab' :
   # Backup
   backup_path                 => '/var/opt/gitlab/backups', #'tmp/backups'
   backup_keep_time            => 604800,
+  backup_hour                 => 2,
+  backup_minute               => 0,
+  backup_month                => '*',
+  backup_monthday             => '*',
+  backup_weekday              => '*',
 
   backup_upload_connection    => 'foobar',
   backup_upload_remote_directory => 'foobar',

--- a/tests/init.pp
+++ b/tests/init.pp
@@ -7,6 +7,12 @@ class { 'gitlab' :
   gitlab_branch           => '7.4.2',
   gitlab_release          => 'basic',
   external_url            => 'http://192.168.33.10',
+  backup_hour             => 2,
+  backup_minute           => 0,
+  backup_month            => 1,
+  backup_monthday         => 1,
+  backup_weekday          => 1,
+
  
 
   # SSL highly recommended


### PR DESCRIPTION
Create a set of parameters which can be supplied to configure the date/time that the backup rake task runs (e.g. weekly rather than daily). If left undefined, the task still runs at the default of 2am daily.